### PR TITLE
Remove the logging to file functionality form the debug function.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -19,7 +19,6 @@ exports.debug = (title, obj, method) => {
   // -------------------------- DEBUG==TRUE Colors----------------------------//
 
   if (process.env.DEBUG) {
-    fs.appendFile('lib/.logs', `${title} ${obj} ${method}`, { flag: 'a' });
     if (method === 'log') {
       const log = out + colors.green(timeOutput) + format + lineSeperator;
       console.log(log);


### PR DESCRIPTION
Hey Selena,

I removed the code, where you log to a file _(lib/.logs)_, in your debug function.

I looked and you appear to have already implemented the use of console.error, console.log and console.warn, so I didn't make any changes there.
